### PR TITLE
fix: change build script to use a specific commit ref

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ val initSubmodules by tasks.registering {
     outputs.upToDateWhen { false }
     doLast {
         Git(layout.projectDirectory)("submodule", "update", "--init", "--remote").executeOut()
+        Git(paperDir)("checkout", providers.gradleProperty("advancedslimepaperRef").getOrElse("HEAD") ).executeOut()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=com.legitimoose.legitslimepaper
 version=1.20.6-R0.1-SNAPSHOT
 
 mcVersion=1.20.6
-#advancedslimepaperRef=2967518cc70a6b15498a36abfc1c2322f8e6a1b4
+advancedslimepaperRef=1.20.6-v10-SRFv12-FINAL
 
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
This probably will fix build errors of the actions AND make it easier for people to build this themselves 😉 

I used a commit ref instead of just changing the submodule's branch because ASP's `dev/1.20.6` branch is actually outdated. (there's a newer commit for 1.20.6 that's not included in there).

I also know that keeping the `submodule update` code might be a bit useless, but if the advancedslimepaperRef is changed and devs don't do `submodule update` manually, they'll have a pretty big headache... (and anyways it doesn't really hurt performance)