### PR TITLE
A heading in the README explaining how to fix the Windows path limit issue and also remove unnecessary template text

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ runShadow - Spin up a test server from the shadowJar archiveFile
 ```
 
 # `Process finished with exit code 128`?
-This error happens because the default Windows path limit is 255 characters. Change the following key in the [registry](https://en.wikipedia.org/wiki/Windows_Registry) to fix it:
+This error occurs because the default Windows path limit is 255 characters. There cannot be paths longer than 255 characters, which is obviously bad, especially if you have many nested folders. Change the following key in the [Windows Registry](https://en.wikipedia.org/wiki/Windows_Registry) to fix it:
 ```
 HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled - Set to 1
 ```
-Make sure to also change the path limit in git:
+Make sure to also allow long paths in git:
 ```
 git config --system core.longpaths true
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # LegitSlimePaper - An AdvancedSlimePaper fork with command related features needed for the Legitimoose server.
 
-This is an example project, showcasing how to setup a fork of Paper (or any other fork using paperweight), using paperweight.
-
-The files of most interest are
-- build.gradle.kts
-- settings.gradle.kts
-- gradle.properties
-
-When updating upstream, be sure to keep the dependencies noted in `build.gradle.kts` in sync with upstream.
-It's also a good idea to use the same version of the Gradle wrapper as upstream.
-
 ## Tasks
 
 ```
@@ -33,7 +23,7 @@ runReobf - Spin up a test server from the reobfJar output jar
 runShadow - Spin up a test server from the shadowJar archiveFile
 ```
 
-# `Process finished with exit code 128`?
+# `Gradle patch task failed with exit code 128 on Windows`?
 This error occurs because the default Windows path limit is 255 characters. There cannot be paths longer than 255 characters, which is obviously bad, especially if you have many nested folders. Change the following key in the [Windows Registry](https://en.wikipedia.org/wiki/Windows_Registry) to fix it:
 ```
 HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled - Set to 1
@@ -43,9 +33,4 @@ Make sure to also allow long paths in git:
 git config --system core.longpaths true
 ```
 
-## Branches
-
-Each branch of this project represents an example:
-
- - [`main` is the standard example](https://github.com/PaperMC/paperweight-examples/tree/main)
- - [`submodules` shows how paperweight can be applied on a fork using the more traditional git submodule system](https://github.com/PaperMC/paperweight-examples/tree/submodules)
+For more information, refer to [PaperMC/paperweight-examples](https://github.com/PaperMC/paperweight-examples) and [PaperMC/Paper/CONTRIBUTING.md](https://github.com/PaperMC/Paper/blob/master/CONTRIBUTING.md). (The CONTRIBUTING.md also explains how to set up the development environment)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ runReobf - Spin up a test server from the reobfJar output jar
 runShadow - Spin up a test server from the shadowJar archiveFile
 ```
 
+# `Process finished with exit code 128`?
+This error happens because the default Windows path limit is 255 characters. Change the following key in the [registry](https://en.wikipedia.org/wiki/Windows_Registry) to fix it:
+```
+HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled - Set to 1
+```
+Also make sure to also change the path limit in git:
+```
+git config --system core.longpaths true
+```
+
 ## Branches
 
 Each branch of this project represents an example:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This error happens because the default Windows path limit is 255 characters. Cha
 ```
 HKLM\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled - Set to 1
 ```
-Also make sure to also change the path limit in git:
+Make sure to also change the path limit in git:
 ```
 git config --system core.longpaths true
 ```


### PR DESCRIPTION
People have trouble building the project because of the weird `Process finished with exit code 128` error, so this would let them know how to fix it

![image](https://github.com/user-attachments/assets/7b024fe9-2cf6-4575-8474-886b8a49ac99)