### PR TITLE
Don't disable the ASP plugin

### DIFF
--- a/patches/server/0013-Don-t-disable-SlimeWorldPlugin-before-world-saving.patch
+++ b/patches/server/0013-Don-t-disable-SlimeWorldPlugin-before-world-saving.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SB2DD <45701824+Mrredstone5230@users.noreply.github.com>
+Date: Tue, 17 Dec 2024 19:08:17 -0500
+Subject: [PATCH] Don't disable SlimeWorldPlugin before world saving
+
+
+diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
+index 1f8bff31ce60f9a1b143e749916fa51cf115f5d7..fb96da2c0b2bb83a80c3a20d4f34cb7a0d6ec55e 100644
+--- a/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
++++ b/src/main/java/io/papermc/paper/plugin/manager/PaperPluginInstanceManager.java
+@@ -235,6 +235,7 @@ class PaperPluginInstanceManager {
+         if (!plugin.isEnabled()) {
+             return;
+         }
++        if (plugin.getName().equals("SlimeWorldPlugin")) return; // Moose - Don't disable the SlimeWorldPlugin before world saving.
+ 
+         String pluginName = plugin.getPluginMeta().getDisplayName();
+ 


### PR DESCRIPTION
This should fix worlds not saving in time.

(Obviously, this patch would make it impossible to disable or reload the ASP plugin, but we don't need to do that...)