### PR TITLE
Don't throw an exception on invalid registry loading

### DIFF
--- a/patches/server/0014-Don-t-throw-an-exception-on-invalid-registry-loading.patch
+++ b/patches/server/0014-Don-t-throw-an-exception-on-invalid-registry-loading.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SB2DD <45701824+Mrredstone5230@users.noreply.github.com>
+Date: Sat, 1 Feb 2025 23:29:25 -0500
+Subject: [PATCH] Don't throw an exception on invalid registry loading
+
+
+diff --git a/src/main/java/net/minecraft/resources/RegistryDataLoader.java b/src/main/java/net/minecraft/resources/RegistryDataLoader.java
+index 3053243866c655829fe2e980446b4abf1da6d37c..a59b42675c585a2d53cc7e4406afbb631aa5b3d5 100644
+--- a/src/main/java/net/minecraft/resources/RegistryDataLoader.java
++++ b/src/main/java/net/minecraft/resources/RegistryDataLoader.java
+@@ -151,10 +151,9 @@ public class RegistryDataLoader {
+         });
+         if (!map.isEmpty()) {
+             logErrors(map);
+-            throw new IllegalStateException("Failed to load registries due to above errors");
+-        } else {
+-            return new RegistryAccess.ImmutableRegistryAccess(list.stream().map(RegistryDataLoader.Loader::registry).toList()).freeze();
++//            throw new IllegalStateException("Failed to load registries due to above errors");  // Moose - Don't throw an exception, just log the errors
+         }
++        return new RegistryAccess.ImmutableRegistryAccess(list.stream().map(RegistryDataLoader.Loader::registry).toList()).freeze();
+     }
+ 
+     private static RegistryOps.RegistryInfoLookup createContext(RegistryAccess baseRegistryManager, List<RegistryDataLoader.Loader<?>> additionalRegistries) {


### PR DESCRIPTION
This should fix worlds not starting because of invalid dimensions or enchantments, by simply ignoring their invalidity 🙈 (They already don't load if they're invalid, so it should be _fiiiiiiiine_)

(This fix could have some _**craaaazy**_ side effects, but at least the worlds will be able to start 😄 )