### PR TITLE
Allow modifying player data

### DIFF
--- a/patches/server/0002-Data-saving.patch
+++ b/patches/server/0002-Data-saving.patch
@@ -80,10 +80,10 @@ index 187336ecaa4262e3f081a88702031b17c6037091..c3fddd09c239f1560bcd9c4b3b4c6514
 \ No newline at end of file
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4434022a6235db9cb453596df7d2aef7bf011363..147b0b33cfc7dfc052f304af8a83185effebf7da 100644
+index ba81a045dc85900b96c6004d03cf9f145e7f3f0f..1a3ea4d6e10e743f5f44731867993738ed026461 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -499,7 +499,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -498,7 +498,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          this.paperConfigurations = services.paperConfigurations(); // Paper - add paper configuration files
      }
  

--- a/patches/server/0003-Added-moose-config-file.patch
+++ b/patches/server/0003-Added-moose-config-file.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added moose config file
 
 diff --git a/src/main/java/com/legitimoose/lsp/MooseConfig.java b/src/main/java/com/legitimoose/lsp/MooseConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4415cb7c5794d2489eb882c531f54e7329c2f000
+index 0000000000000000000000000000000000000000..707e7de82d1bfff8b964e6b03bfa25e6b914712e
 --- /dev/null
 +++ b/src/main/java/com/legitimoose/lsp/MooseConfig.java
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,122 @@
 +package com.legitimoose.lsp;
 +
 +import com.google.common.base.Throwables;
@@ -125,6 +125,11 @@ index 0000000000000000000000000000000000000000..4415cb7c5794d2489eb882c531f54e73
 +        MooseConfig.allowedExtraCommands = MooseConfig.getList("allowed-extra-commands-in-cmd-blocks", new ArrayList<>(List.of(
 +
 +        )));
++    }
++
++    public static boolean allowPlayerDataModification = false;
++    private static void allowPlayerDataModification() {
++        MooseConfig.allowPlayerDataModification = MooseConfig.getBoolean("allow-player-data-modification", false);
 +    }
 +}
 \ No newline at end of file

--- a/patches/server/0007-Allow-negative-explosion-radius.patch
+++ b/patches/server/0007-Allow-negative-explosion-radius.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow negative explosion radius
 Co-authored-by: Nico314159 <nicolino.will@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index ad57bf49476192dea6a7367cbd0ad3f11e142e1b..c9c7d11fb89a2b59865a48e6e16a188fe1f8986b 100644
+index f696afd7e241bf1966a2d505b5d59bff824b43e4..7b4582c6314e0719f9968947ada22e21f448a804 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
-@@ -340,7 +340,7 @@ public class Explosion {
+@@ -341,7 +341,7 @@ public class Explosion {
          this.hitPlayers = Maps.newHashMap();
          this.level = world;
          this.source = entity;
@@ -18,7 +18,7 @@ index ad57bf49476192dea6a7367cbd0ad3f11e142e1b..c9c7d11fb89a2b59865a48e6e16a188f
          this.x = x;
          this.y = y;
          this.z = z;
-@@ -402,11 +402,7 @@ public class Explosion {
+@@ -403,11 +403,7 @@ public class Explosion {
      }
  
      public void explode() {

--- a/patches/server/0015-Allow-modifying-player-data.patch
+++ b/patches/server/0015-Allow-modifying-player-data.patch
@@ -5,20 +5,17 @@ Subject: [PATCH] Allow modifying player data
 
 
 diff --git a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
-index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..c017fdb898df75e3f80cc327e4e55bfbc9f8db6f 100644
+index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..e3894e47ef0e924e35f97d2cb00ae6eb2a1ad879 100644
 --- a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
 +++ b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
-@@ -4,37 +4,41 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
+@@ -1,5 +1,6 @@
+ package net.minecraft.server.commands.data;
+ 
++import com.legitimoose.lsp.MooseConfig;
+ import com.mojang.brigadier.builder.ArgumentBuilder;
  import com.mojang.brigadier.context.CommandContext;
  import com.mojang.brigadier.exceptions.CommandSyntaxException;
- import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-+
- import java.util.Locale;
- import java.util.UUID;
- import java.util.function.Function;
-+
- import net.minecraft.advancements.critereon.NbtPredicate;
- import net.minecraft.commands.CommandSourceStack;
+@@ -12,11 +13,13 @@ import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
  import net.minecraft.commands.arguments.EntityArgument;
  import net.minecraft.commands.arguments.NbtPathArgument;
@@ -35,42 +32,14 @@ index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..c017fdb898df75e3f80cc327e4e55bfb
  import net.minecraft.world.entity.player.Player;
  
  public class EntityDataAccessor implements DataAccessor {
-     private static final SimpleCommandExceptionType ERROR_NO_PLAYERS = new SimpleCommandExceptionType(Component.translatable("commands.data.entity.invalid"));
-     public static final Function<String, DataCommands.DataProvider> PROVIDER = argumentName -> new DataCommands.DataProvider() {
--            @Override
--            public DataAccessor access(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
--                return new EntityDataAccessor(EntityArgument.getEntity(context, argumentName));
--            }
-+        @Override
-+        public DataAccessor access(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-+            return new EntityDataAccessor(EntityArgument.getEntity(context, argumentName));
-+        }
- 
--            @Override
--            public ArgumentBuilder<CommandSourceStack, ?> wrap(
--                ArgumentBuilder<CommandSourceStack, ?> argument,
--                Function<ArgumentBuilder<CommandSourceStack, ?>, ArgumentBuilder<CommandSourceStack, ?>> argumentAdder
--            ) {
--                return argument.then(Commands.literal("entity").then(argumentAdder.apply(Commands.argument(argumentName, EntityArgument.entity()))));
--            }
--        };
-+        @Override
-+        public ArgumentBuilder<CommandSourceStack, ?> wrap(
-+            ArgumentBuilder<CommandSourceStack, ?> argument,
-+            Function<ArgumentBuilder<CommandSourceStack, ?>, ArgumentBuilder<CommandSourceStack, ?>> argumentAdder
-+        ) {
-+            return argument.then(Commands.literal("entity").then(argumentAdder.apply(Commands.argument(argumentName, EntityArgument.entity()))));
-+        }
-+    };
-     private final Entity entity;
- 
-     public EntityDataAccessor(Entity entity) {
-@@ -44,7 +48,63 @@ public class EntityDataAccessor implements DataAccessor {
+@@ -44,7 +47,65 @@ public class EntityDataAccessor implements DataAccessor {
      @Override
      public void setData(CompoundTag nbt) throws CommandSyntaxException {
          if (this.entity instanceof Player) {
 -            throw ERROR_NO_PLAYERS.create();
 +            // Moose start - Allow modifying player data
++            if (!MooseConfig.allowPlayerDataModification)
++                throw ERROR_NO_PLAYERS.create();
 +            // From - https://github.com/eclipseisoffline/modifyplayerdata/
 +            CompoundTag oldNbt = NbtPredicate.getEntityTagToCompare(entity);
 +
@@ -86,7 +55,7 @@ index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..c017fdb898df75e3f80cc327e4e55bfb
 +                    case "Invulnerable" -> player.setInvulnerable(((NumericTag) nbt.get(key)).getAsByte() != 0);
 +                    case "Motion" -> {
 +                        ListTag velocity = (ListTag) nbt.get(key);
-+                        player.setDeltaMovement(velocity.getDouble(0), velocity.getDouble(1), velocity.getDouble(2));
++                        player.setDeltaMovement(((NumericTag)velocity.get(0)).getAsDouble(), ((NumericTag)velocity.get(1)).getAsDouble(), ((NumericTag)velocity.get(2)).getAsDouble());
 +                        player.connection.sendPacket(new ClientboundSetEntityMotionPacket(player));
 +                    }
 +                    case "NoGravity" -> player.setNoGravity(((NumericTag) nbt.get(key)).getAsByte() != 0);

--- a/patches/server/0015-Allow-modifying-player-data.patch
+++ b/patches/server/0015-Allow-modifying-player-data.patch
@@ -5,10 +5,20 @@ Subject: [PATCH] Allow modifying player data
 
 
 diff --git a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
-index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..cb20b5b276d843d7a04c9b08feb4f90814ef2ce2 100644
+index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..c017fdb898df75e3f80cc327e4e55bfbc9f8db6f 100644
 --- a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
 +++ b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
-@@ -12,11 +12,13 @@ import net.minecraft.commands.CommandSourceStack;
+@@ -4,37 +4,41 @@ import com.mojang.brigadier.builder.ArgumentBuilder;
+ import com.mojang.brigadier.context.CommandContext;
+ import com.mojang.brigadier.exceptions.CommandSyntaxException;
+ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
++
+ import java.util.Locale;
+ import java.util.UUID;
+ import java.util.function.Function;
++
+ import net.minecraft.advancements.critereon.NbtPredicate;
+ import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
  import net.minecraft.commands.arguments.EntityArgument;
  import net.minecraft.commands.arguments.NbtPathArgument;
@@ -25,7 +35,37 @@ index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..cb20b5b276d843d7a04c9b08feb4f908
  import net.minecraft.world.entity.player.Player;
  
  public class EntityDataAccessor implements DataAccessor {
-@@ -44,7 +46,51 @@ public class EntityDataAccessor implements DataAccessor {
+     private static final SimpleCommandExceptionType ERROR_NO_PLAYERS = new SimpleCommandExceptionType(Component.translatable("commands.data.entity.invalid"));
+     public static final Function<String, DataCommands.DataProvider> PROVIDER = argumentName -> new DataCommands.DataProvider() {
+-            @Override
+-            public DataAccessor access(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+-                return new EntityDataAccessor(EntityArgument.getEntity(context, argumentName));
+-            }
++        @Override
++        public DataAccessor access(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
++            return new EntityDataAccessor(EntityArgument.getEntity(context, argumentName));
++        }
+ 
+-            @Override
+-            public ArgumentBuilder<CommandSourceStack, ?> wrap(
+-                ArgumentBuilder<CommandSourceStack, ?> argument,
+-                Function<ArgumentBuilder<CommandSourceStack, ?>, ArgumentBuilder<CommandSourceStack, ?>> argumentAdder
+-            ) {
+-                return argument.then(Commands.literal("entity").then(argumentAdder.apply(Commands.argument(argumentName, EntityArgument.entity()))));
+-            }
+-        };
++        @Override
++        public ArgumentBuilder<CommandSourceStack, ?> wrap(
++            ArgumentBuilder<CommandSourceStack, ?> argument,
++            Function<ArgumentBuilder<CommandSourceStack, ?>, ArgumentBuilder<CommandSourceStack, ?>> argumentAdder
++        ) {
++            return argument.then(Commands.literal("entity").then(argumentAdder.apply(Commands.argument(argumentName, EntityArgument.entity()))));
++        }
++    };
+     private final Entity entity;
+ 
+     public EntityDataAccessor(Entity entity) {
+@@ -44,7 +48,63 @@ public class EntityDataAccessor implements DataAccessor {
      @Override
      public void setData(CompoundTag nbt) throws CommandSyntaxException {
          if (this.entity instanceof Player) {
@@ -72,6 +112,18 @@ index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..cb20b5b276d843d7a04c9b08feb4f908
 +                            player.connection.sendPacket(new ClientboundSetCarriedItemPacket(slot));
 +                        }
 +                    }
++                    case "HasVisualFire" -> player.hasVisualFire = (((NumericTag) nbt.get(key)).getAsByte() != 0);
++                    case "TicksFrozen" -> player.setTicksFrozen(((NumericTag) nbt.get(key)).getAsInt());
++                    case "FallFlying" -> {
++                        if (((NumericTag) nbt.get(key)).getAsByte() != 0) {
++                            player.startFallFlying();
++                        } else {
++                            player.stopFallFlying();
++                        }
++                    }
++                    case "FoodExhaustionLevel" -> player.getFoodData().setExhaustion(((NumericTag) nbt.get(key)).getAsFloat());
++                    case "FoodLevel" -> player.getFoodData().setFoodLevel(((NumericTag) nbt.get(key)).getAsInt());
++                    case "FoodSaturationLevel" -> player.getFoodData().setSaturation(((NumericTag) nbt.get(key)).getAsFloat());
 +                }
 +            }
 +            // Moose end - Allow modifying player data

--- a/patches/server/0015-Allow-modifying-player-data.patch
+++ b/patches/server/0015-Allow-modifying-player-data.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow modifying player data
 
 
 diff --git a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
-index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..be31384194f255496efa10c86e95fcb2dc92d0ca 100644
+index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..cb20b5b276d843d7a04c9b08feb4f90814ef2ce2 100644
 --- a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
 +++ b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
-@@ -12,10 +12,10 @@ import net.minecraft.commands.CommandSourceStack;
+@@ -12,11 +12,13 @@ import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
  import net.minecraft.commands.arguments.EntityArgument;
  import net.minecraft.commands.arguments.NbtPathArgument;
@@ -17,12 +17,15 @@ index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..be31384194f255496efa10c86e95fcb2
 -import net.minecraft.nbt.Tag;
 +import net.minecraft.nbt.*;
  import net.minecraft.network.chat.Component;
++import net.minecraft.network.protocol.game.ClientboundSetCarriedItemPacket;
 +import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
 +import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.world.entity.Entity;
++import net.minecraft.world.entity.player.Inventory;
  import net.minecraft.world.entity.player.Player;
  
-@@ -44,7 +44,44 @@ public class EntityDataAccessor implements DataAccessor {
+ public class EntityDataAccessor implements DataAccessor {
+@@ -44,7 +46,51 @@ public class EntityDataAccessor implements DataAccessor {
      @Override
      public void setData(CompoundTag nbt) throws CommandSyntaxException {
          if (this.entity instanceof Player) {
@@ -61,6 +64,13 @@ index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..be31384194f255496efa10c86e95fcb2
 +                        player.getAbilities().setWalkingSpeed(abilities.getFloat("walkSpeed"));
 +
 +                        player.onUpdateAbilities();
++                    }
++                    case "SelectedItemSlot" -> {
++                        int slot = ((NumericTag) nbt.get(key)).getAsInt();
++                        if (Inventory.isHotbarSlot(slot)) {
++                            player.getInventory().selected = slot;
++                            player.connection.sendPacket(new ClientboundSetCarriedItemPacket(slot));
++                        }
 +                    }
 +                }
 +            }

--- a/patches/server/0015-Allow-modifying-player-data.patch
+++ b/patches/server/0015-Allow-modifying-player-data.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Omri H <76548146+OmriPH@users.noreply.github.com>
+Date: Tue, 25 Feb 2025 19:23:58 +0200
+Subject: [PATCH] Allow modifying player data
+
+
+diff --git a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
+index a0755d4cdaf2bf7cba799a246345c8ba85ec6042..be31384194f255496efa10c86e95fcb2dc92d0ca 100644
+--- a/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
++++ b/src/main/java/net/minecraft/server/commands/data/EntityDataAccessor.java
+@@ -12,10 +12,10 @@ import net.minecraft.commands.CommandSourceStack;
+ import net.minecraft.commands.Commands;
+ import net.minecraft.commands.arguments.EntityArgument;
+ import net.minecraft.commands.arguments.NbtPathArgument;
+-import net.minecraft.nbt.CompoundTag;
+-import net.minecraft.nbt.NbtUtils;
+-import net.minecraft.nbt.Tag;
++import net.minecraft.nbt.*;
+ import net.minecraft.network.chat.Component;
++import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
++import net.minecraft.server.level.ServerPlayer;
+ import net.minecraft.world.entity.Entity;
+ import net.minecraft.world.entity.player.Player;
+ 
+@@ -44,7 +44,44 @@ public class EntityDataAccessor implements DataAccessor {
+     @Override
+     public void setData(CompoundTag nbt) throws CommandSyntaxException {
+         if (this.entity instanceof Player) {
+-            throw ERROR_NO_PLAYERS.create();
++            // Moose start - Allow modifying player data
++            // From - https://github.com/eclipseisoffline/modifyplayerdata/
++            CompoundTag oldNbt = NbtPredicate.getEntityTagToCompare(entity);
++
++            ServerPlayer player = (ServerPlayer) entity;
++            for (String key : nbt.getAllKeys()) {
++                if (nbt.get(key).equals(oldNbt.get(key))) {
++                    continue;
++                }
++                switch (key) {
++                    case "Air" -> player.setAirSupply(((NumericTag) nbt.get(key)).getAsInt());
++                    case "Fire" -> player.setRemainingFireTicks(((NumericTag) nbt.get(key)).getAsInt());
++                    case "Glowing" -> player.setGlowingTag(((NumericTag) nbt.get(key)).getAsByte() != 0);
++                    case "Invulnerable" -> player.setInvulnerable(((NumericTag) nbt.get(key)).getAsByte() != 0);
++                    case "Motion" -> {
++                        ListTag velocity = (ListTag) nbt.get(key);
++                        player.setDeltaMovement(velocity.getDouble(0), velocity.getDouble(1), velocity.getDouble(2));
++                        player.connection.sendPacket(new ClientboundSetEntityMotionPacket(player));
++                    }
++                    case "NoGravity" -> player.setNoGravity(((NumericTag) nbt.get(key)).getAsByte() != 0);
++                    case "PortalCooldown" -> player.setPortalCooldown(((NumericTag) nbt.get(key)).getAsInt());
++                    case "Silent" -> player.setSilent(((NumericTag) nbt.get(key)).getAsByte() != 0);
++                    case "Health" -> player.setHealth(((NumericTag) nbt.get(key)).getAsFloat());
++                    case "abilities" -> {
++                        CompoundTag abilities = (CompoundTag) nbt.get(key);
++                        player.getAbilities().flying = abilities.getBoolean("flying");
++                        player.getAbilities().setFlyingSpeed(abilities.getFloat("flySpeed"));
++                        player.getAbilities().instabuild = abilities.getBoolean("instabuild");
++                        player.getAbilities().invulnerable = abilities.getBoolean("invulnerable");
++                        player.getAbilities().mayBuild = abilities.getBoolean("mayBuild");
++                        player.getAbilities().mayfly = abilities.getBoolean("mayfly");
++                        player.getAbilities().setWalkingSpeed(abilities.getFloat("walkSpeed"));
++
++                        player.onUpdateAbilities();
++                    }
++                }
++            }
++            // Moose end - Allow modifying player data
+         } else {
+             UUID uUID = this.entity.getUUID();
+             this.entity.load(nbt);


### PR DESCRIPTION
Ports [Modify Player Data](https://github.com/eclipseisoffline/modifyplayerdata/) to LegitSlimePaper

Allowed tags:
- Air
- Fire
- Glowing
- Invulnerable
- Motion
- NoGravity
- PortalCooldown
- Silent
- Health
- abilities
- SelectedItemSlot
- HasVisualFire
- TicksFrozen
- FallFlying
- FoodExhaustionLevel
- FoodLevel
- FoodSaturationLevel