### PR TITLE
Add permission node to allow f3+I

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/legitslimepaper-server/aspaper-patches/files/src/main/java/com/infernalsuite/asp/SlimeNMSBridgeImpl.java.patch
+++ b/legitslimepaper-server/aspaper-patches/files/src/main/java/com/infernalsuite/asp/SlimeNMSBridgeImpl.java.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/com/infernalsuite/asp/SlimeNMSBridgeImpl.java
 +++ b/src/main/java/com/infernalsuite/asp/SlimeNMSBridgeImpl.java
-@@ -74,6 +_,7 @@
+@@ -82,6 +_,7 @@
          // Some stuff is needed when loading overworld world
          SlimeLevelInstance instance = ((SlimeInMemoryWorld) this.loadInstance(defaultWorld, Level.OVERWORLD)).getInstance();
          DimensionDataStorage worldpersistentdata = instance.getDataStorage();

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1263,7 +_,7 @@
+     @Override
+     public void handleEntityTagQuery(ServerboundEntityTagQueryPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
+-        if (this.player.hasPermissions(2)) {
++        if (this.player.hasPermissions(2) || this.player.getBukkitEntity().hasPermission("minecraft.nbt.query")) { // Moose - Add nbt.query permission
+             Entity entity = this.player.level().getEntity(packet.getEntityId());
+             if (entity != null) {
+                 CompoundTag compoundTag = entity.saveWithoutId(new CompoundTag());
+@@ -1285,7 +_,7 @@
+     @Override
+     public void handleBlockEntityTagQuery(ServerboundBlockEntityTagQueryPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.serverLevel());
+-        if (this.player.hasPermissions(2)) {
++        if (this.player.hasPermissions(2) || this.player.getBukkitEntity().hasPermission("minecraft.nbt.query")) { // Moose - Add nbt.query permission
+             BlockEntity blockEntity = this.player.level().getBlockEntity(packet.getPos());
+             CompoundTag compoundTag = blockEntity != null ? blockEntity.saveWithoutMetadata(this.player.registryAccess()) : null;
+             this.player.connection.send(new ClientboundTagQueryPacket(packet.getTransactionId(), compoundTag));

--- a/legitslimepaper-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java.patch
+++ b/legitslimepaper-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java.patch
@@ -1,0 +1,10 @@
+--- a/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/permissions/CraftDefaultPermissions.java
+@@ -18,6 +_,7 @@
+         DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".debugstick.always", "Gives the user the ability to use the debug stick in all game modes", org.bukkit.permissions.PermissionDefault.FALSE/* , parent */); // Paper - should not have this parent, as it's not a "vanilla" utility
+         DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".commandblock", "Gives the user the ability to use command blocks.", org.bukkit.permissions.PermissionDefault.OP, parent); // Paper
+         // Spigot end
++        DefaultPermissions.registerPermission(CraftDefaultPermissions.ROOT + ".nbt.query", "Gives the user the ability to use f3+I to query server-side nbt", org.bukkit.permissions.PermissionDefault.OP, parent); // Moose
+         parent.recalculatePermissibles();
+     }
+ }


### PR DESCRIPTION
Players in legitimoose worlds that are on the admin list cannot use f3+I.

If you use f3+I on entities or tile-entities, the vanilla Minecraft client does the following:
- If the client thinks it has op permission level >= 2, it will send a tag query packet to the server and wait for a response
- If the client thinks it has op permission level < 2, it will return client-side data

On legitimoose, the server tells "admin" clients that they are opped, but does not actually op them. Thus, when someone who is an admin in a world uses f3+I, the client will send an nbt query packet but the server does not respond, so the client just waits forever.

This PR adds a `minecraft.nbt.query` permission node that, when given, makes the server to respond to a player's nbt queries as if they were opped. That way, if you give admin players this permission, f3+I will behave like normal.

I also updated the gradle wrapper since it wouldn't build for me otherwise.