### PR TITLE
Warning users about compiling on system with less than 10 GB of RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,13 @@
 
 Apply patches with `./gradlew applyAllPatches` and then run a dev server with `./gradlew runServer`. You can generate a mojmap jar with `./gradlew createMojmapBundlerJar`.
 
-## Important note
-
-When compiling, 10 GB of RAM are allocated to Gradle by default. If your system has just a bit more than 10 GB or lower it will freeze, potentially corrupting important stuff. To fix this you should lower the Xmx value in the gradle.properties file. 4 GB or more should be enough.
-
 ## How to contribute
 1. You first need to have the currently applied patches with `./gradlew applyAllPatches` and then you can start working on the code.
-2. Then, you can edit the code in the `legitslimepaper-server/` folder
-3. After you are done, you can save your changes to the "local git repo" with `./gradlew fixupMinecraftSourcePatches` (The task name may depend on what you are working on, eg `fixupPaperServerFilePatches`. Calling more than you need should be fine even if it throws a git error.)
-4. Once all the changes are in the "local git repo", you can update the patch files with `./gradlew rebuildAllServerPatches`.
-5. Finally, you can create a pull request with your changes. (You normally should only be commiting patch files. Please don't commit anything from `legitslimepaper-server/src/minecraft/`!!!)
+2. If the applyAllPatches task fails, it could be because you don't have enough RAM. To fix this, refer to the "Set Gradle memory limit section.
+3. Then, you can edit the code in the `legitslimepaper-server/` folder
+4. After you are done, you can save your changes to the "local git repo" with `./gradlew fixupMinecraftSourcePatches` (The task name may depend on what you are working on, eg `fixupPaperServerFilePatches`. Calling more than you need should be fine even if it throws a git error.)
+5. Once all the changes are in the "local git repo", you can update the patch files with `./gradlew rebuildAllServerPatches`.
+6. Finally, you can create a pull request with your changes. (You normally should only be commiting patch files. Please don't commit anything from `legitslimepaper-server/src/minecraft/`!!!)
 
 ### Small notes
 - If you need to change the `build.gradle.kts.patch` files, using `./gradlew rebuildSlimeworldmanagerSingleFilePatches` will automatically update all these patch files after modifications were made.
@@ -28,5 +25,13 @@ Make sure to also allow long paths in git:
 ```
 git config --system core.longpaths true
 ```
+
+## Set Gradle memory limit
+By default, 10 GB of RAM are allocated to Gradle. This causes computers with not enough memory to freeze while executing the task.
+To fix this, lower the Xmx value in the gradle.properties file. An example is provided below:
+```
+org.gradle.jvmargs=-Xmx4G
+```
+This allocates 4 GB of RAM to Gradle which in most cases should be enough.
 
 For more information, refer to [PaperMC/paperweight-examples](https://github.com/PaperMC/paperweight-examples) and [PaperMC/Paper/CONTRIBUTING.md](https://github.com/PaperMC/Paper/blob/master/CONTRIBUTING.md). (The CONTRIBUTING.md also explains how to set up the development environment)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Apply patches with `./gradlew applyAllPatches` and then run a dev server with `./gradlew runServer`. You can generate a mojmap jar with `./gradlew createMojmapBundlerJar`.
 
+## Important note
+
+When compiling, 10 GB of RAM are allocated to Gradle by default. If your system has just a bit more than 10 GB or lower it will freeze, potentially corrupting important stuff. To fix this you should lower the Xmx value in the gradle.properties file. 4 GB or more should be enough.
 
 ## How to contribute
 1. You first need to have the currently applied patches with `./gradlew applyAllPatches` and then you can start working on the code.


### PR DESCRIPTION
In the gradle.properties file, there is a value that allocates 10 GB of RAM to Gradle. This will cause systems with not very much RAM to freeze completely. This pull request adds a warning to the README to inform users before they compile LegitSlimePaper. 