### PR TITLE
fix: made safemode really safe

### DIFF
--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/Main.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/Main.java.patch
@@ -35,12 +35,21 @@
  import org.slf4j.Logger;
  
  public class Main {
-@@ -140,6 +_,8 @@
-                 LOGGER.info("Initialized '{}' and '{}'", path1.toAbsolutePath(), path2.toAbsolutePath());
+@@ -141,6 +_,8 @@
                  return;
              }
-+
-+            MooseConfig.init((File) optionSet.valueOf("moose-settings")); // Moose - Load moose.yml
  
++            MooseConfig.init((File) optionSet.valueOf("moose-settings")); // Moose - Load moose.yml
++
              // Spigot start
              boolean eulaAgreed = Boolean.getBoolean("com.mojang.eula.agree");
+             if (eulaAgreed) {
+@@ -230,7 +_,7 @@
+                 LOGGER.warn("Safe mode active, only vanilla datapack will be loaded");
+             }
+ 
+-            PackRepository packRepository = ServerPacksSource.createPackRepository(levelStorageAccess);
++            PackRepository packRepository = hasOptionSpec ? ServerPacksSource.createVanillaTrustedRepository() : ServerPacksSource.createPackRepository(levelStorageAccess); // Moose
+             // CraftBukkit start
+             File bukkitDataPackFolder = new File(levelStorageAccess.getLevelPath(net.minecraft.world.level.storage.LevelResource.DATAPACK_DIR).toFile(), "bukkit");
+             if (!bukkitDataPackFolder.exists()) {

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/network/ServerGamePacketListenerImpl.java.patch
@@ -18,7 +18,7 @@
              BlockEntity blockEntity = this.player.level().getBlockEntity(packet.getPos());
              CompoundTag compoundTag = blockEntity != null ? blockEntity.saveWithoutMetadata(this.player.registryAccess()) : null;
              this.send(new ClientboundTagQueryPacket(packet.getTransactionId(), compoundTag));
-@@ -3548,7 +_,7 @@
+@@ -3492,7 +_,7 @@
      @Override
      public void handleChangeGameMode(ServerboundChangeGameModePacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
-@@ -2106,7 +_,7 @@
+@@ -2105,7 +_,7 @@
      }
  
      public boolean canUseGameMasterBlocks() {


### PR DESCRIPTION
Before this, paper would actually still load datapacks with safemode on. Heck, safemode didnt even work with functions anymore! This is a pretty harsh fix to fix that but also more, by literally disabling datapack file loading when safemode is on. (And forcing only vanilla datapacks to work)

I tested and this fixed the functions issues and also allowed safemode for dialogs. I also have high hopes that this may also work with invalid custom dimensions (although I haven't tested that).