### PR TITLE
Feat/enderchest serialization disabling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=1.21.8-R0.1-SNAPSHOT
 mcVersion=1.21.8
 
 #Update with ASP!! (also update gradle/libs.versions.toml)
-aspRef=39ec52c993fc558264be0710b13f97178dcb7b81
+aspRef=6e2b4ea58f6686dd7b2601d0c83012537d9db29d
 apiVersion=4.2.0-SNAPSHOT
 
 org.gradle.caching=true

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/arguments/selector/options/EntitySelectorOptions.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/arguments/selector/options/EntitySelectorOptions.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/commands/arguments/selector/options/EntitySelectorOptions.java
++++ b/net/minecraft/commands/arguments/selector/options/EntitySelectorOptions.java
+@@ -341,7 +_,7 @@
+                     boolean var9;
+                     try (ProblemReporter.ScopedCollector scopedCollector = new ProblemReporter.ScopedCollector(entity.problemPath(), LOGGER)) {
+                         TagValueOutput tagValueOutput = TagValueOutput.createWithContext(scopedCollector, entity.registryAccess());
+-                        entity.saveWithoutId(tagValueOutput);
++                        entity.saveWithoutId(tagValueOutput, !com.legitimoose.lsp.MooseConfig.disableEnderchestSerializationInSelectors, false, false); // Moose - Disable enderchest serializing in nbt selectors
+                         if (entity instanceof ServerPlayer serverPlayer) {
+                             ItemStack selectedItem = serverPlayer.getInventory().getSelectedItem();
+                             if (!selectedItem.isEmpty()) {

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/server/level/ServerPlayer.java
++++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -565,8 +_,8 @@
+     }
+ 
+     @Override
+-    protected void addAdditionalSaveData(ValueOutput output) {
+-        super.addAdditionalSaveData(output);
++    protected void addAdditionalSaveData(ValueOutput output, boolean includeAll) { // Moose - Disable enderchest serializing in nbt selectors
++        super.addAdditionalSaveData(output, includeAll); // Moose
+         output.store("warden_spawn_tracker", WardenSpawnTracker.CODEC, this.wardenSpawnTracker);
+         this.storeGameTypes(output);
+         output.putBoolean("seenCredits", this.seenCredits);

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -1,5 +1,24 @@
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
+@@ -834,7 +_,7 @@
+     }
+ 
+     @Override
+-    protected void addAdditionalSaveData(ValueOutput output) {
++    protected void addAdditionalSaveData(ValueOutput output, boolean includeAll) {
+         super.addAdditionalSaveData(output);
+         NbtUtils.addCurrentDataVersion(output);
+         this.inventory.save(output.list("Inventory", ItemStackWithSlot.CODEC));
+@@ -847,7 +_,8 @@
+         output.putInt("Score", this.getScore());
+         this.foodData.addAdditionalSaveData(output);
+         output.store("abilities", Abilities.Packed.CODEC, this.abilities.pack());
+-        this.enderChestInventory.storeAsSlots(output.list("EnderItems", ItemStackWithSlot.CODEC));
++        if (includeAll) // Moose - Disable enderchest serializing in nbt selectors
++            this.enderChestInventory.storeAsSlots(output.list("EnderItems", ItemStackWithSlot.CODEC));
+         if (!this.getShoulderEntityLeft().isEmpty()) {
+             output.store("ShoulderEntityLeft", CompoundTag.CODEC, this.getShoulderEntityLeft());
+         }
 @@ -2105,7 +_,7 @@
      }
  

--- a/legitslimepaper-server/src/main/java/com/legitimoose/lsp/MooseConfig.java
+++ b/legitslimepaper-server/src/main/java/com/legitimoose/lsp/MooseConfig.java
@@ -119,4 +119,9 @@ public class MooseConfig {
     private static void allowPlayerDataModification() {
         MooseConfig.allowPlayerDataModification = MooseConfig.getBoolean("allow-player-data-modification", false);
     }
+
+    public static boolean disableEnderchestSerializationInSelectors = false;
+    private static void disableEnderchestSerializationInSelectors() {
+        MooseConfig.disableEnderchestSerializationInSelectors = MooseConfig.getBoolean("disable-enderchest-serialization-in-selectors", false);
+    }
 }


### PR DESCRIPTION
To reduce lag in the lobby, this disables enderchest serialization when using an nbt "test" in selectors.

Afterwards, using an "nbt test" can still lead to some lag, mostly with the Inventory tag, but since inventories reset any time players relog, I don't believe it will be as impactful to add something similar for it than with enderchests.