### PR TITLE
Feat/bit operations

### DIFF
--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/arguments/OperationArgument.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/arguments/OperationArgument.java.patch
@@ -1,0 +1,29 @@
+--- a/net/minecraft/commands/arguments/OperationArgument.java
++++ b/net/minecraft/commands/arguments/OperationArgument.java
+@@ -48,7 +_,9 @@
+ 
+     @Override
+     public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+-        return SharedSuggestionProvider.suggest(new String[]{"=", "+=", "-=", "*=", "/=", "%=", "<", ">", "><"}, builder);
++        return SharedSuggestionProvider.suggest(new String[]{"=", "+=", "-=", "*=", "/=", "%=", "<", ">", "><"
++            , "&=", "|=", "^=", "~=", "<<=", ">>=", ">>>="}, // LegitSlimePaper - Add Bit operations
++            builder);
+     }
+ 
+     @Override
+@@ -86,6 +_,15 @@
+             };
+             case "<" -> Math::min;
+             case ">" -> Math::max;
++            // LegitSlimePaper start - Add Bit operations
++            case "&=" -> (targetScore, sourceScore) -> targetScore & sourceScore;
++            case "|=" -> (targetScore, sourceScore) -> targetScore | sourceScore;
++            case "^=" -> (targetScore, sourceScore) -> targetScore ^ sourceScore;
++            case "~=" -> (targetScore, sourceScore) -> ~sourceScore;
++            case "<<=" -> (targetScore, sourceScore) -> targetScore << sourceScore;
++            case ">>=" -> (targetScore, sourceScore) -> targetScore >> sourceScore;
++            case ">>>=" -> (targetScore, sourceScore) -> targetScore >>> sourceScore;
++            // LegitSlimePaper end - Add Bit operations
+             default -> throw ERROR_INVALID_OPERATION.create();
+         };
+     }

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/commands/ScoreboardCommand.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/server/commands/ScoreboardCommand.java.patch
@@ -1,0 +1,19 @@
+--- a/net/minecraft/server/commands/ScoreboardCommand.java
++++ b/net/minecraft/server/commands/ScoreboardCommand.java
+@@ -66,6 +_,7 @@
+     );
+ 
+     public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context) {
++        OperationArgument operationArgument = OperationArgument.operation(); // LegitSlimePaper - Add Bit operations
+         dispatcher.register(
+             Commands.literal("scoreboard")
+                 .requires(Commands.hasPermission(2))
+@@ -365,7 +_,7 @@
+                                         .then(
+                                             Commands.argument("targetObjective", ObjectiveArgument.objective())
+                                                 .then(
+-                                                    Commands.argument("operation", OperationArgument.operation())
++                                                    Commands.argument("operation", operationArgument).suggests(operationArgument::listSuggestions) // LegitSlimePaper - Add Bit operations
+                                                         .then(
+                                                             Commands.argument("source", ScoreHolderArgument.scoreHolders())
+                                                                 .suggests(ScoreHolderArgument.SUGGEST_SCORE_HOLDERS)


### PR DESCRIPTION
This PR adds support for the following operations in the operator argument:

- &=
- |=
- ^=
- ~=
- <<=
- \>\>=
- \>\>\>=

These are useful for datapack/command expressions involving bit manipulation.

The implementation appends these to the existing suggestion list and updates the argument parser accordingly.

Let me know if you'd like additional operators or code style adjustments.