### PR TITLE
Feat/function macro argument escaping

### DIFF
--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/functions/MacroFunction.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/functions/MacroFunction.java.patch
@@ -8,7 +8,7 @@
  import net.minecraft.commands.ExecutionCommandSource;
  import net.minecraft.commands.FunctionInstantiationException;
  import net.minecraft.commands.execution.UnboundEntryAction;
-@@ -51,6 +_,7 @@
+@@ -51,20 +_,35 @@
  
      @Override
      public InstantiatedFunction<T> instantiate(@Nullable CompoundTag arguments, CommandDispatcher<T> dispatcher) throws FunctionInstantiationException {
@@ -16,3 +16,33 @@
          if (arguments == null) {
              throw new FunctionInstantiationException(Component.translatable("commands.function.error.missing_arguments", Component.translationArg(this.id())));
          } else {
+             List<String> list = new ArrayList<>(this.parameters.size());
+ 
+             for (String string : this.parameters) {
+-                Tag tag = arguments.get(string);
++                // LegitSlimePaper start - Allow Escaping Function Macro Arguments
++                boolean escapedArgument = string.charAt(0) == '\\';
++                Tag tag;
++                if (escapedArgument) {
++                    tag = arguments.get(string.substring(1));
++                } else {
++                    tag = arguments.get(string);
++                }
++                // LegitSlimePaper end - Allow Escaping Function Macro Arguments
+                 if (tag == null) {
+                     throw new FunctionInstantiationException(
+                         Component.translatable("commands.function.error.missing_argument", Component.translationArg(this.id()), string)
+                     );
+                 }
+ 
+-                list.add(stringify(tag));
++                // LegitSlimePaper start - Allow Escaping Function Macro Arguments
++                String substitutedParameter = stringify(tag);
++                if (escapedArgument) {
++                    substitutedParameter = StringTag.escapeWithoutQuotes(substitutedParameter);
++                }
++                list.add(substitutedParameter);
++                // LegitSlimePaper end - Allow Escaping Function Macro Arguments
+             }
+ 
+             InstantiatedFunction<T> instantiatedFunction = this.cache.getAndMoveToLast(list);

--- a/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/functions/StringTemplate.java.patch
+++ b/legitslimepaper-server/minecraft-patches/sources/net/minecraft/commands/functions/StringTemplate.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/commands/functions/StringTemplate.java
++++ b/net/minecraft/commands/functions/StringTemplate.java
+@@ -45,7 +_,17 @@
+     }
+ 
+     public static boolean isValidVariableName(String variableName) {
+-        for (int i = 0; i < variableName.length(); i++) {
++        // LegitSlimePaper start - Allow Escaping Function Macro Arguments
++        int variableNameLength = variableName.length();
++        if (variableNameLength == 0) {
++            return true;
++        }
++        int i = 0;
++        if (variableName.charAt(0) == '\\') {
++            i = 1;
++        }
++        for (; i < variableNameLength; i++) {
++        // LegitSlimePaper end - Allow Escaping Function Macro Arguments
+             char c = variableName.charAt(i);
+             if (!Character.isLetterOrDigit(c) && c != '_') {
+                 return false;


### PR DESCRIPTION
These two patches enable function macros to resolve string variables natively within quotes.

This facilitates direct string concatenation and dynamic NBT pathing:

- `"$(\varA)$(\varB)"`: Supports multi-variable concatenation.
- `{list:["$(\var)"]}`: Allows variable injection into NBT arrays.
- `map."$(\var)"`: Enables dynamic keys in storage lookups.